### PR TITLE
make BBs pormake compatible

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4-dev
+current_version = 0.0.4
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.0.5-dev
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2022, Kevin Maik Jablonka"
 author = "Kevin Maik Jablonka"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.4"
+release = "0.0.5-dev"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2022, Kevin Maik Jablonka"
 author = "Kevin Maik Jablonka"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.4-dev"
+release = "0.0.4"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = moffragmentor
-version = 0.0.4-dev
+version = 0.0.4
 description = Splits MOFs into metal nodes and linkers.
 author = Kevin Maik Jablonka
 author_email = mail@kjablonka.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = moffragmentor
-version = 0.0.4
+version = 0.0.5-dev
 description = Splits MOFs into metal nodes and linkers.
 author = Kevin Maik Jablonka
 author_email = mail@kjablonka.com

--- a/src/moffragmentor/sbu/sbu.py
+++ b/src/moffragmentor/sbu/sbu.py
@@ -13,6 +13,7 @@ from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.core import Molecule, Structure
 from pymatgen.io.babel import BabelMolAdaptor
 from rdkit import Chem
+from rdkit.Chem.Descriptors import NumRadicalElectrons
 from scipy.spatial.distance import pdist
 
 from moffragmentor.utils import pickle_dump
@@ -209,6 +210,10 @@ class SBU:
     @property
     def is_edge(self):
         return len(self.branching_coords) == 2
+
+    @property
+    def num_radical_electrons(self):
+        return NumRadicalElectrons(self.rdkit_mol)
 
     def __len__(self):
         """Return the number of atoms in the molecule."""

--- a/src/moffragmentor/version.py
+++ b/src/moffragmentor/version.py
@@ -14,7 +14,7 @@ __all__ = [
     "get_git_hash",
 ]
 
-VERSION = "0.0.4-dev"
+VERSION = "0.0.4"
 
 
 def get_git_hash() -> str:

--- a/src/moffragmentor/version.py
+++ b/src/moffragmentor/version.py
@@ -14,7 +14,7 @@ __all__ = [
     "get_git_hash",
 ]
 
-VERSION = "0.0.4"
+VERSION = "0.0.5-dev"
 
 
 def get_git_hash() -> str:


### PR DESCRIPTION
does not work for non-carboxy MOFs. 
For some reasons, the dummy structure for the N-linkers is wrong